### PR TITLE
Prevent the RpcClient cleanup thread from cleaning up the client object that is about to be used

### DIFF
--- a/trpc-core/src/main/java/com/tencent/trpc/core/cluster/RpcClusterClientManager.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/cluster/RpcClusterClientManager.java
@@ -127,7 +127,7 @@ public class RpcClusterClientManager {
             } finally {
                 logger.warn("RpcClient in clusterName={}, naming={}, remove rpc client{}, due to unused time > {} ms",
                         bConfig.getName(), bConfig.getNamingOptions().getServiceNaming(),
-                        e.getProtocolConfig().toSimpleString(), e.getProtocolConfig().getIdleTimeout());
+                        e.getProtocolConfig().toSimpleString(), bConfig.getIdleTimeout());
             }
         }));
     }
@@ -252,7 +252,7 @@ public class RpcClusterClientManager {
 
         private RpcClient delegate;
 
-        private long lastUsedNanos = System.nanoTime();
+        private volatile long lastUsedNanos = System.nanoTime();
 
         RpcClientProxy(RpcClient delegate) {
             this.delegate = delegate;


### PR DESCRIPTION
1. RpcClientProxy的lastUsedNanos使volatile，避免多线程可见性不一致；
2. 使用ConcurrentMap的compute，在返回之前updateLastUsedNanos，保证其他线程get的时候拿到的是都是已经更新过最后使用时间的