### PR TITLE
bugfix: fix the typos in trpc-jave-demo's yaml

### DIFF
--- a/trpc-demo/trpc-java-demo/src/main/resources/trpc_java_client.yaml
+++ b/trpc-demo/trpc-java-demo/src/main/resources/trpc_java_client.yaml
@@ -9,19 +9,19 @@ client: # Client configs
     - demoFilter
   service:
     - name: trpc.TestApp.TestServer.Greeter1  # Service name
-      interface: com.tencent.trpc.demo.proto.GreeterserviceAPI  # Service interface
+      interface: com.tencent.trpc.demo.proto.GreeterServiceAPI  # Service interface
       naming_url: ip://127.0.0.1:12321  # Router address
       network: tcp                      # Network type, tcp or udp
     - name: trpc.TestApp.TestServer.Greeter2  # Service name
-      interface: com.tencent.trpc.demo.proto.Greeterservice2API # Service interface
+      interface: com.tencent.trpc.demo.proto.GreeterService2API # Service interface
       naming_url: ip://127.0.0.1:12321  # Router address
       network: udp                      # Network type, tcp or udp
     - name: trpc.TestApp.TestServer.Greeter3  # Service name
-      interface: com.tencent.trpc.demo.proto.GreeterserviceAPI  # Service interface
+      interface: com.tencent.trpc.demo.proto.GreeterServiceAPI  # Service interface
       naming_url: ip://127.0.0.1:12322  # Router address
       protocol: http                    # Protocol type, default is trpc
     - name: trpc.TestApp.TestServer.Greeter4  # Service name
-      interface: com.tencent.trpc.demo.proto.Greeterservice2API # Service interface
+      interface: com.tencent.trpc.demo.proto.GreeterService2API # Service interface
       naming_url: ip://127.0.0.1:12322  # Router address
       protocol: http                    # Protocol type, default is trpc
 


### PR DESCRIPTION
When trying to run the `ClientTest` of trpc-java-demo, I got the following error
```
java.lang.IllegalStateException: Yaml config parse exception, position(client->service), interface name is com.tencent.trpc.demo.proto.GreeterserviceAPI
        at com.tencent.trpc.container.config.yaml.BackendConfigParser.loadClass(BackendConfigParser.java:86) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.config.yaml.BackendConfigParser.lambda$parseConfig$0(BackendConfigParser.java:70) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]     
        at java.util.Optional.map(Optional.java:260) ~[?:?]
        at com.tencent.trpc.core.utils.BinderUtils.bind(BinderUtils.java:160) ~[trpc-core-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.core.utils.BinderUtils.bind(BinderUtils.java:144) ~[trpc-core-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.config.yaml.BackendConfigParser.parseConfig(BackendConfigParser.java:69) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at com.tencent.trpc.container.config.yaml.BackendConfigParser.parseConfigMap(BackendConfigParser.java:47) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.config.yaml.ClientConfigParser.parseClientConfig(ClientConfigParser.java:42) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.config.ApplicationConfigParser.doParse(ApplicationConfigParser.java:86) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.config.ApplicationConfigParser.parse(ApplicationConfigParser.java:41) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.container.container.DefaultContainer.start(DefaultContainer.java:37) ~[trpc-container-default-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.server.container.TRPC.start(TRPC.java:32) [trpc-server-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.server.main.Main.main(Main.java:36) [trpc-server-1.4.0-SNAPSHOT.jar:?]
        at com.tencent.trpc.demo.example.yaml.ClientTest.main(ClientTest.java:32) [classes/:?]
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:279) [exec-maven-plugin-3.1.0.jar:?]
        at java.lang.Thread.run(Thread.java:842) [?:?]
```
After checking, I found some typos for interface names in `trpc_java_client.yaml`. The interface names don't match those defined in the `demo.proto`