### PR TITLE
feature: 客户端callee优先使用用户指定的配置

### DIFF
--- a/trpc-container/trpc-container-default/src/test/java/com/tencent/trpc/container/config/yaml/YamlApplicationConfigParserTest.java
+++ b/trpc-container/trpc-container-default/src/test/java/com/tencent/trpc/container/config/yaml/YamlApplicationConfigParserTest.java
@@ -125,7 +125,7 @@ public class YamlApplicationConfigParserTest {
         assertEquals(backendConfig.getNamespace(), "dev2");
         assertEquals(backendConfig.getGroup(), "g1");
         assertEquals(backendConfig.getVersion(), "v1");
-        assertEquals(backendConfig.getCallee(), "127.0.0.1:12345");
+        assertEquals(backendConfig.getCallee(), "trpc.TestApp.TestServer.GreeterCallee");
         assertEquals(backendConfig.getFilters().get(0), "filter");
         assertEquals(backendConfig.getRequestTimeout(), 2000);
         assertEquals(backendConfig.getProtocol(), "trpc");

--- a/trpc-core/src/main/java/com/tencent/trpc/core/common/config/BackendConfig.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/common/config/BackendConfig.java
@@ -428,7 +428,9 @@ public class BackendConfig extends BaseProtocolConfig {
     protected void setCalleeInfo() {
         String serviceNaming = getNamingOptions().getServiceNaming();
         // callee is set to serviceNaming, setting is not supported
-        callee = serviceNaming;
+        if (StringUtils.isEmpty(callee)) {
+            callee = serviceNaming;
+        }
 
         // in the TRPC scenario, serviceId is in the format trpc.calleeapp.calleeserver.calleeservice
         if (StringUtils.isNotBlank(callee) && callee.startsWith(Constants.STANDARD_NAMING_PRE)) {

--- a/trpc-core/src/test/java/com/tencent/trpc/core/common/config/BackendConfigTest.java
+++ b/trpc-core/src/test/java/com/tencent/trpc/core/common/config/BackendConfigTest.java
@@ -149,16 +149,14 @@ public class BackendConfigTest {
     }
 
     @Test
-    public void testSetCallee() {
-        ExtensionLoader
-                .registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+    public void testNoSetCallee() {
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
         BackendConfig config = new BackendConfig();
         config.setName("trpc.calleeapp.calleeserver.calleeservice.calleemethod");
         config.setNamingUrl("ip://127.0.0.1:8888");
         config.setExtMap(ImmutableMap.of("attalog", (Object) "attalog"));
         config.setFilters(Lists.newArrayList("attalog"));
         config.setGroup("group");
-        config.setCallee("trpc.app.server.service");
         config.init();
         assertEquals(config.getCalleeApp(), "");
         assertEquals(config.getCalleeServer(), "");
@@ -167,9 +165,25 @@ public class BackendConfigTest {
     }
 
     @Test
+    public void testSetCallee() {
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+        BackendConfig config = new BackendConfig();
+        config.setName("trpc.calleeapp.calleeserver.calleeservice.calleemethod");
+        config.setNamingUrl("ip://127.0.0.1:8888");
+        config.setExtMap(ImmutableMap.of("attalog", (Object) "attalog"));
+        config.setFilters(Lists.newArrayList("attalog"));
+        config.setGroup("group");
+        config.setCallee("trpc.app.server.service");
+        config.init();
+        assertEquals(config.getCalleeApp(), "app");
+        assertEquals(config.getCalleeServer(), "server");
+        assertEquals(config.getCalleeService(), "service");
+        assertEquals("trpc.app.server.service", config.getCallee());
+    }
+
+    @Test
     public void testNameSpace() {
-        ExtensionLoader
-                .registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
         BackendConfig config = new BackendConfig();
         config.setName("trpc.calleeapp.calleeserver.calleeservice.calleemethod");
         config.setNamingUrl("ip://127.0.0.1:8888");
@@ -183,16 +197,15 @@ public class BackendConfigTest {
         config.init();
         config.toString();
         assertEquals(0, config.getNamingMap().size());
-        assertEquals(config.getCalleeApp(), "");
-        assertEquals(config.getCalleeServer(), "");
-        assertEquals(config.getCalleeService(), "");
+        assertEquals(config.getCalleeApp(), "app");
+        assertEquals(config.getCalleeServer(), "server");
+        assertEquals(config.getCalleeService(), "service");
         assertEquals(config.getNamingOptions().getExtMap().get("namespace"), "abc");
     }
 
     @Test
     public void testIp() {
-        ExtensionLoader
-                .registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
         ExtensionLoader.registerPlugin(ThreadWorkerPool.newThreadWorkerPoolConfig("thread", 10, Boolean.FALSE));
         BackendConfig config = new BackendConfig();
         config.setNamingUrl("ip://127.0.0.1:8888");
@@ -237,10 +250,8 @@ public class BackendConfigTest {
 
     @Test
     public void test() {
-        ExtensionLoader
-                .registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
-        ExtensionLoader.registerPlugin(ThreadWorkerPool.newThreadWorkerPoolConfig("thread", 10,
-                10, Boolean.FALSE));
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+        ExtensionLoader.registerPlugin(ThreadWorkerPool.newThreadWorkerPoolConfig("thread", 10, Boolean.FALSE));
         BackendConfig config = new BackendConfig();
         config.setCallee("trpc.calleeapp.calleeserver.calleeservice.calleemethod");
         config.setNamingUrl("ip://127.0.0.1:8888");
@@ -273,9 +284,9 @@ public class BackendConfigTest {
             assertEquals(config.getServiceInterface(), GenericClient.class);
             assertEquals(config.getRequestTimeout(), 1234);
             assertEquals(config.getVersion(), "v888");
-            assertEquals(config.getCalleeApp(), "");
-            assertEquals(config.getCalleeServer(), "");
-            assertEquals(config.getCalleeService(), "");
+            assertEquals(config.getCalleeApp(), "calleeapp");
+            assertEquals(config.getCalleeServer(), "calleeserver");
+            assertEquals(config.getCalleeService(), "calleeservice");
             ServiceId serviceId = config.toNamingServiceId();
             assertEquals(serviceId.getGroup(), "group");
             assertEquals(serviceId.getServiceName(), "127.0.0.1:8888");
@@ -294,8 +305,7 @@ public class BackendConfigTest {
         config.setServiceInterface(GenericClient.class);
         config.setName("client");
         config.setNamingUrl("ip://127.0.0.1:12345");
-        ConfigManager.getInstance().getClientConfig().getBackendConfigMap()
-                .put("client", config);
+        ConfigManager.getInstance().getClientConfig().getBackendConfigMap().put("client", config);
         ConsumerConfig<GenericClient> consumerConfig = new ConsumerConfig<>();
         consumerConfig.setBackendConfig(config);
         consumerConfig.setServiceInterface(GenericClient.class);
@@ -317,8 +327,7 @@ public class BackendConfigTest {
 
     @Test
     public void testNotDefault() {
-        ExtensionLoader
-                .registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
+        ExtensionLoader.registerPlugin(new PluginConfig("attalog", Filter.class, RemoteLoggerTest.class));
         ExtensionLoader.registerPlugin(ThreadWorkerPool.newThreadWorkerPoolConfig("thread", 10, Boolean.FALSE));
         BackendConfig config = new BackendConfig();
         config.setName("trpc.calleeapp.calleeserver.calleeservice.calleemethod");


### PR DESCRIPTION
当用户配置了客户端的callee参数时，框架不进行参数覆盖。