### PR TITLE
feat: add ServiceConfig field to ProtocolConfig

### DIFF
--- a/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ProtocolConfig.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ProtocolConfig.java
@@ -48,6 +48,8 @@ public class ProtocolConfig extends BaseProtocolConfig implements Cloneable {
     protected volatile boolean setDefault = false;
     protected volatile boolean inited = false;
 
+    protected ServiceConfig serviceConfig;
+
     public static ProtocolConfig newInstance() {
         return new ProtocolConfig();
     }
@@ -242,6 +244,16 @@ public class ProtocolConfig extends BaseProtocolConfig implements Cloneable {
 
     public boolean isInited() {
         return inited;
+    }
+
+    public ServiceConfig getServiceConfig() {
+        return serviceConfig;
+    }
+
+    public  void setServiceConfig(ServiceConfig serviceConfig) {
+        checkFiledModifyPrivilege();
+        Preconditions.checkArgument(serviceConfig != null, "serviceConfig cannot be null");
+        this.serviceConfig = serviceConfig;
     }
 
 }

--- a/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ProtocolConfig.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ProtocolConfig.java
@@ -252,7 +252,6 @@ public class ProtocolConfig extends BaseProtocolConfig implements Cloneable {
 
     public  void setServiceConfig(ServiceConfig serviceConfig) {
         checkFiledModifyPrivilege();
-        Preconditions.checkArgument(serviceConfig != null, "serviceConfig cannot be null");
         this.serviceConfig = serviceConfig;
     }
 

--- a/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ServiceConfig.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/common/config/ServiceConfig.java
@@ -402,6 +402,7 @@ public class ServiceConfig extends BaseProtocolConfig {
         tempProtocolConfig.setReusePort(this.getReusePort());
         tempProtocolConfig.setSign(this.getSign());
         tempProtocolConfig.setDefault();
+        tempProtocolConfig.setServiceConfig(this);
         return tempProtocolConfig;
     }
 

--- a/trpc-core/src/test/java/com/tencent/trpc/core/common/config/ProtocolConfigTest.java
+++ b/trpc-core/src/test/java/com/tencent/trpc/core/common/config/ProtocolConfigTest.java
@@ -14,6 +14,7 @@ package com.tencent.trpc.core.common.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -90,6 +91,8 @@ public class ProtocolConfigTest {
         config.setExplicitFlushAfterFlushes(1024);
         config.setCompressMinBytes(10);
         config.setDefault();
+        ServiceConfig serviceConfig = new ServiceConfig();
+        config.setServiceConfig(serviceConfig);
         assertEquals("127.1.1.1", config.getIp());
         assertEquals("", config.getName());
         assertEquals(8080, config.getPort());
@@ -124,5 +127,6 @@ public class ProtocolConfigTest {
         assertFalse(config.useEpoll());
         assertEquals(10, config.getCompressMinBytes());
         assertTrue(config.isSetDefault());
+        assertSame(serviceConfig, config.getServiceConfig());
     }
 }


### PR DESCRIPTION
Add ServiceConfig field to ProtocolConfig to provide more service infomation for the next RpcServer's creation.