### PR TITLE
fix: add isAvailable check in getInvoker to prevent idle eviction race condition

### DIFF
--- a/trpc-core/src/main/java/com/tencent/trpc/core/cluster/def/DefClusterInvoker.java
+++ b/trpc-core/src/main/java/com/tencent/trpc/core/cluster/def/DefClusterInvoker.java
@@ -72,7 +72,10 @@ public class DefClusterInvoker<T> extends AbstractClusterInvoker<T> {
     protected ConsumerInvokerProxy<T> getInvoker(ServiceInstance instance) {
         String key = toUniqKey(instance);
         ConsumerInvokerProxy<T> result = invokerCache.get(key);
-        return Optional.ofNullable(result).orElseGet(() -> createInvoker(instance));
+        if (result != null && result.isAvailable()) {
+            return result;
+        }
+        return createInvoker(instance);
     }
 
     @SuppressWarnings("rawtypes")

--- a/trpc-core/src/test/java/com/tencent/trpc/core/cluster/def/DefClusterInvokerTest.java
+++ b/trpc-core/src/test/java/com/tencent/trpc/core/cluster/def/DefClusterInvokerTest.java
@@ -33,12 +33,14 @@ import com.tencent.trpc.core.worker.WorkerPoolManager;
 import com.tencent.trpc.core.worker.handler.TrpcThreadExceptionHandler;
 import com.tencent.trpc.core.worker.spi.WorkerPool;
 import com.tencent.trpc.core.worker.support.thread.ThreadWorkerPool;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -246,6 +248,57 @@ public class DefClusterInvokerTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetInvokerSkipsUnavailableCachedInvoker() throws Exception {
+        Assert.assertFalse(consumerInvokerProxy.isAvailable());
+
+        // Put the unavailable invoker into invokerCache via reflection
+        Field cacheField = DefClusterInvoker.class.getDeclaredField("invokerCache");
+        cacheField.setAccessible(true);
+        ConcurrentMap<String, ConsumerInvokerProxy<GenericClient>> cache =
+                (ConcurrentMap<String, ConsumerInvokerProxy<GenericClient>>) cacheField.get(defClusterInvoker);
+
+        ServiceInstance instance = new ServiceInstance("127.0.0.1", 12345);
+        String key = "127.0.0.1:12345:null";
+        cache.put(key, consumerInvokerProxy);
+
+        // Spy on defClusterInvoker and mock createInvoker to return a new available proxy
+        DefClusterInvoker<GenericClient> spy = PowerMockito.spy(defClusterInvoker);
+        ConsumerInvokerProxy<GenericClient> newProxy = PowerMockito.mock(ConsumerInvokerProxy.class);
+        PowerMockito.when(newProxy.isAvailable()).thenReturn(true);
+        PowerMockito.doReturn(newProxy).when(spy).createInvoker(instance);
+
+        ConsumerInvokerProxy<GenericClient> result = spy.getInvoker(instance);
+
+        // Should not return the unavailable cached invoker
+        Assert.assertNotSame(consumerInvokerProxy, result);
+        // Should return the new available one from createInvoker
+        Assert.assertSame(newProxy, result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetInvokerReturnsAvailableCachedInvoker() throws Exception {
+        // Put an available invoker into invokerCache via reflection
+        Field cacheField = DefClusterInvoker.class.getDeclaredField("invokerCache");
+        cacheField.setAccessible(true);
+        ConcurrentMap<String, ConsumerInvokerProxy<GenericClient>> cache =
+                (ConcurrentMap<String, ConsumerInvokerProxy<GenericClient>>) cacheField.get(defClusterInvoker);
+
+        ServiceInstance instance = new ServiceInstance("127.0.0.1", 12345);
+        String key = "127.0.0.1:12345:null";
+
+        // Create an available proxy (client.isAvailable() = true)
+        ConsumerInvokerProxy<GenericClient> availableProxy = PowerMockito.mock(ConsumerInvokerProxy.class);
+        PowerMockito.when(availableProxy.isAvailable()).thenReturn(true);
+        cache.put(key, availableProxy);
+
+        // getInvoker should return the cached available proxy directly
+        ConsumerInvokerProxy<GenericClient> result = defClusterInvoker.getInvoker(instance);
+        Assert.assertSame(availableProxy, result);
     }
 
 }


### PR DESCRIPTION
## What

Add an `isAvailable()` check on the fast path of `DefClusterInvoker.getInvoker()`.

## Why

When the idle scanner (`scanUnusedClient`) closes an RpcClient, there is a time window between `client.close()` and the `closeFuture` callback removing the invoker from `invokerCache`. During this window, business threads can obtain a stale invoker whose underlying transport is already shut down, resulting in `Client stop` errors.

## How

If the cached invoker's RpcClient is no longer available (STOPPING/STOPPED state), fall through to `createInvoker()` which rebuilds a new RpcClient under proper synchronization.